### PR TITLE
Include fast convolution based dice probabilities

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -3,9 +3,10 @@ import matplotlib.pyplot as plt
 import re
 import itertools
 import math
+from collections import defaultdict
 
 
-def combinations_tool(num, sides):
+def combinations_tool_orig(num, sides):
     results = {}
     line_results = []
     # Generate all combinations from set of possible die rolls, allow repeats
@@ -53,7 +54,44 @@ def combinations_tool(num, sides):
     results = {k: float(v)/float(total)*100 for k,v in results.items()}
     binomial_results = binomialize(results)
     return [results, binomial_results, str(num)+"d"+str(sides), line_results]
-        
+
+
+def conv(a, b):
+    """
+    Combine two roll results.
+    
+    > r1d2 = {1: 1, 2:1}
+    > r2d2 = conv(r1d2, r1d2)
+    > r2d2
+    {2: 1, 3: 2, 4: 1}
+    
+    > r1d6 = {v: 1 for v in range(1, 6+1)}
+    > r2d6 = conv(r1d6, r1d6)
+    > r2d6
+    {2: 1, 3: 2, 4: 3, 5: 4, 6: 5, 7: 6, 8: 5, 9: 4, 10: 3, 11: 2, 12: 1}
+    
+    > r4d6 = conv(r2d6, r2d6)
+    """
+    o = defaultdict(int)
+    for r1, c1 in a.items():
+        for r2, c2 in b.items():
+            o[r1+r2] += c1*c2
+    return o
+
+def combinations_tool_conv(num, sides):
+    die = {v:1 for v in range(1, sides+1)}
+    results = {0:1}  # 1 way to make a sum of 0
+    for roll_number in range(num):
+        results = conv(results, die)
+            
+    # Map all the values to their respective proportion vs the total, make percentage 
+    total = sum(results.values())
+    results = {k: float(v)/float(total)*100 for k,v in results.items()}
+    binomial_results = binomialize(results)
+    return [results, binomial_results, str(num)+"d"+str(sides), None]  # line_results is missing
+
+combinations_tool = combinations_tool_conv
+
 def binomialize(results):
     binomial_results = {}
     last_key = None


### PR DESCRIPTION
re: [Dice Roll Distributions: Statistics, and the Importance of Runtime Efficiency](https://medium.com/swlh/dice-roll-distributions-statistics-and-the-importance-of-runtime-efficiency-d8ce3402db15)

A faster way to compute the dice rolls is using the [convolution of the probability mass functions](https://en.wikipedia.org/wiki/Convolution_of_probability_distributions).

Which an intimidating mathy way of saying something that isn't too complicated.

The intuition is to count the number of ways to create each sum. For example, in a 1d3 roll there is 1 way to create each of 1, 2, or 3:
```
1d3 = {1:1, 2:1, 3:1}
```

A 2d3 roll, combines two 1d3 rolls:
```
(roll1, roll2) = roll1 + roll2
(1, 1) = 2
(1, 2) = 3
(1, 3) = 4
(2, 1) = 3
(2, 2) = 4
(2, 3) = 5
(3, 1) = 4
(3, 2) = 5
(3, 3) = 6

# Then count the number of ways to make each sum:
2d3 = {2: 1, 3:2, 4:3, 5:2, 6:1}
```

A 3d3 roll could combine a 1d3 and 2d3 roll:
```
1d3 = {1:1, 2:1, 3:1}
2d3 = {2: 1, 3:2, 4:3, 5:2, 6:1}

# We need to take the counts into consideration

(roll1: c1, roll2: c2) = sum: c1 * c2
(2:1, 1:1) = 3: 1*1
(2:1, 2:1) = 4: 1*1
(2:1, 3:1) = 5: 1*1
(3:2, 1:1) = 4: 2*1
(3:2, 2:1) = 5: 2*1
(3:2, 3:1) = 6: 2*1
(4:3, 1:1) = 5: 3*1
(4:3, 2:1) = 6: 3*1
(4:3, 3:1) = 7: 3*1
(5:2, 1:1) = 6: 2*1
(5:2, 2:1) = 7: 2*1
(5:2, 3:1) = 8: 2*1
(6:1, 1:1) = 7: 1*1
(6:1, 2:1) = 8: 1*1
(6:1, 3:1) = 9: 1*1

3d3 = {
  3: 1,  # 1
  4: 3,  # 1+2
  5: 6,  # 1+2+3
  6: 7,  # 2+3+2
  7: 6,  # 3+2+1
  8: 3,  # 2+1
  9: 1   # 1
}
```